### PR TITLE
Add person table

### DIFF
--- a/data/oscars.sql
+++ b/data/oscars.sql
@@ -32,3 +32,15 @@ FOREIGN KEY (ceremony_id) REFERENCES ceremony(id),
 FOREIGN KEY (category_id) REFERENCES category(id),
 FOREIGN KEY (film_id) REFERENCES film(id)
 );
+
+DROP TABLE IF EXISTS person;
+CREATE TABLE person (
+id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+surname char(50) NOT NULL,
+forename char(50) NOT NULL,
+display_name char(100),
+sort_name char(100),
+birth_date date,
+death_date date,
+imdb_key char(50)
+);


### PR DESCRIPTION
Fixes #1

Add a new `person` table to the `data/oscars.sql` file.

* Add a `person` table definition with columns: id, surname, forename, display name, sort name, birth date, death date, and IMDB key.
* Set the `id` column as the primary key and auto-incremented.
* Make the `display_name`, `sort_name`, `birth_date`, `death_date`, and `imdb_key` columns nullable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/oscars/pull/2?shareId=8f60c5d0-9f8d-403e-a231-bb2e6992777e).