### PR TITLE
Add a date column to the ceremony table

### DIFF
--- a/data/oscars.sql
+++ b/data/oscars.sql
@@ -3,7 +3,8 @@ CREATE TABLE ceremony (
 id integer NOT NULL PRIMARY KEY,
 ceremony_year integer NOT NULL UNIQUE,
 release_year integer NOT NULL UNIQUE,
-ceremony_number integer NOT NULL UNIQUE
+ceremony_number integer NOT NULL UNIQUE,
+date date NOT NULL
 );
 
 DROP TABLE IF EXISTS category;


### PR DESCRIPTION
Fixes #3

Add a date column to the ceremony table in the `data/oscars.sql` file.

* Add a new column `date` to the `ceremony` table.
* Set the data type of the `date` column to `date`.
* Ensure the `date` column is not nullable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/oscars/pull/4?shareId=55cc88b4-842a-45ba-a44d-c74d114a2dfc).